### PR TITLE
Add cdk-addons=true label to all templates and select on that

### DIFF
--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -50,6 +50,10 @@ def render_template(file, context, required=True):
     data = [part for part in yaml.load_all(content) if part]
     for part in data:
         part["metadata"]["labels"]["cdk-addons"] = "true"
+        # Adding kubernetes.io/cluster-service=true label for now. We should
+        # probably remove this later and stop using it after the
+        # cdk-addons=true label has been live for a couple releases.
+        part["metadata"]["labels"]["kubernetes.io/cluster-service"] = "true"
     content = yaml.dump_all(data)
 
     with open(dest, "w") as f:
@@ -61,14 +65,14 @@ def apply_addons():
     args = ["apply",
             "-f", dns_svc,
             "--namespace=kube-system",
-            "-l", "cdk-addons=true",
+            "-l", "kubernetes.io/cluster-service=true",
             "--force"]
     kubectl(*args)
     args = ["apply",
             "-f", addon_dir,
             "--recursive",
             "--namespace=kube-system",
-            "-l", "cdk-addons=true",
+            "-l", "kubernetes.io/cluster-service=true",
             "--prune=true",
             "--force"]
     kubectl(*args)

--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -47,10 +47,10 @@ def render_template(file, context, required=True):
     content = template.render(context)
 
     # apply cdk-addons=true label
-    data = [yaml.load(part) for part in content.split('\n---') if part.strip()]
+    data = [part for part in yaml.load_all(content) if part]
     for part in data:
         part["metadata"]["labels"]["cdk-addons"] = "true"
-    content = '\n---\n'.join(yaml.dump(part) for part in data)
+    content = yaml.dump_all(data)
 
     with open(dest, "w") as f:
         f.write(content)

--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -3,6 +3,7 @@
 import os
 import shutil
 import subprocess
+import yaml
 from jinja2 import Template
 
 template_dir = os.path.join(os.environ["SNAP"], "templates")
@@ -43,8 +44,16 @@ def render_template(file, context, required=True):
         return
     with open(source) as f:
         template = Template(f.read())
+    content = template.render(context)
+
+    # apply cdk-addons=true label
+    data = [yaml.load(part) for part in content.split('\n---') if part.strip()]
+    for part in data:
+        part["metadata"]["labels"]["cdk-addons"] = "true"
+    content = '\n---\n'.join(yaml.dump(part) for part in data)
+
     with open(dest, "w") as f:
-        f.write(template.render(context))
+        f.write(content)
 
 def apply_addons():
     # Apply dns service first and then recursively the rest.
@@ -52,22 +61,15 @@ def apply_addons():
     args = ["apply",
             "-f", dns_svc,
             "--namespace=kube-system",
-            "-l", "kubernetes.io/cluster-service=true",
+            "-l", "cdk-addons=true",
             "--force"]
     kubectl(*args)
     args = ["apply",
             "-f", addon_dir,
             "--recursive",
             "--namespace=kube-system",
-            "-l", "kubernetes.io/cluster-service=true",
+            "-l", "cdk-addons=true",
             "--prune=true",
-            "--force"]
-    kubectl(*args)
-    args = ["apply",
-            "-f", addon_dir,
-            "--recursive",
-            "--namespace=kube-system",
-            "-l", "k8s-app=kubernetes-dashboard",
             "--force"]
     kubectl(*args)
 


### PR DESCRIPTION
This is a follow-up to #20, which doesn't quite work right when `enable-dashboard-addons=false`, for two reasons:

1. With no `--prune=true` when applying the `k8s-app=kubernetes-dashboard` group, the dashboard addons are never removed.
2. Even with `--prune=true`, `kubectl apply` blows up when no addons are selected:

```
2017-10-18 19:25:34 DEBUG update-status error: no objects passed to apply
2017-10-18 19:25:34 DEBUG update-status Traceback (most recent call last):
2017-10-18 19:25:34 DEBUG update-status   File "/snap/cdk-addons/x1/apply", line 102, in <module>
2017-10-18 19:25:34 DEBUG update-status     main()
2017-10-18 19:25:34 DEBUG update-status   File "/snap/cdk-addons/x1/apply", line 13, in main
2017-10-18 19:25:34 DEBUG update-status     apply_addons()
2017-10-18 19:25:34 DEBUG update-status   File "/snap/cdk-addons/x1/apply", line 73, in apply_addons
2017-10-18 19:25:34 DEBUG update-status     kubectl(*args)
2017-10-18 19:25:34 DEBUG update-status   File "/snap/cdk-addons/x1/apply", line 82, in kubectl
2017-10-18 19:25:34 DEBUG update-status     return subprocess.check_output(cmd)
2017-10-18 19:25:34 DEBUG update-status   File "/usr/lib/python3.5/subprocess.py", line 626, in check_output
2017-10-18 19:25:34 DEBUG update-status     **kwargs).stdout
2017-10-18 19:25:34 DEBUG update-status   File "/usr/lib/python3.5/subprocess.py", line 708, in run
2017-10-18 19:25:34 DEBUG update-status     output=stdout, stderr=stderr)
2017-10-18 19:25:34 DEBUG update-status subprocess.CalledProcessError: Command '['/snap/cdk-addons/x1/kubectl', 'apply', '-f', '/root/snap/cdk-addons/x1/addons', '--recursive', '--namespace=kube-system', '-l', 'k8s-app=kubernetes-dashboard', '--prune=true', '--force']' returned non-zero exit status 1
```

The proposed fix in this PR is to remove our dependence on the `k8s-app=kubernetes-dashboard` and `kubernetes.io/cluster-service=true` labels, and instead apply our own `cdk-addons=true` label to all addon definitions. Then we can use that instead.

@ktsakalozos can you take a look at this? Thanks.