### PR TITLE
Update kube-dns template path for 1.9

### DIFF
--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -24,10 +24,7 @@ def render_templates():
             "num_nodes": get_node_count()
         }
     }
-    render_template("kubedns-sa.yaml", context, required=False)
-    render_template("kubedns-cm.yaml", context, required=False)
-    render_template("kubedns-controller.yaml", context)
-    render_template("kubedns-svc.yaml", context)
+    render_template("kube-dns.yaml", context)
     if get_snap_config("enable-dashboard") == "true":
         render_template("kubernetes-dashboard.yaml", context)
         render_template("influxdb-grafana-controller.yaml", context)
@@ -61,7 +58,7 @@ def render_template(file, context, required=True):
 
 def apply_addons():
     # Apply dns service first and then recursively the rest.
-    dns_svc = os.path.join(addon_dir, "kubedns-svc.yaml")
+    dns_svc = os.path.join(addon_dir, "kube-dns.yaml")
     args = ["apply",
             "-f", dns_svc,
             "--namespace=kube-system",

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -88,20 +88,8 @@ def get_addon_templates():
     os.mkdir(dest)
     with kubernetes_repo() as repo:
         log.info("Copying addons to " + dest)
-        add_addon(repo, "dns/kubedns-sa.yaml", dest, required=False)
-        add_addon(repo, "dns/kubedns-cm.yaml", dest, required=False)
-        try:
-            add_addon(repo, "dns/kubedns-controller.yaml.in",
-                      dest + "/kubedns-controller.yaml")
-            add_addon(repo, "dns/kubedns-svc.yaml.in",
-                      dest + "/kubedns-svc.yaml")
-        except IOError as e:
-            # fall back to the older filenames
-            log.debug(e)
-            add_addon(repo, "dns/skydns-rc.yaml.in",
-                      dest + "/kubedns-controller.yaml")
-            add_addon(repo, "dns/skydns-svc.yaml.in",
-                      dest + "/kubedns-svc.yaml")
+
+        add_addon(repo, "dns/kube-dns.yaml.in", dest + "/kube-dns.yaml")
 
         influxdb = "cluster-monitoring/influxdb"
         add_addon(repo, influxdb + "/grafana-service.yaml", dest)


### PR DESCRIPTION
Error trying to build cdk-addons for v1.9.0-beta.0:

```
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/kubernetes__c5vd_o/cluster/addons/dns/kubedns-controller.yaml.in'
```

Upstream has replaced the 4 kubedns templates with a single [kube-dns.yaml.in](https://github.com/kubernetes/kubernetes/blob/v1.9.0-beta.0/cluster/addons/dns/kube-dns.yaml.in).

Merging this PR to master should only affect our builds for 1.9 and onward, I think. I just made a release-1.8 branch, and we already have release-1.7 and release-1.6.

I've tested that this builds successfully, but have not run it in a cluster. Let's get this merged in anyway so we can at least get our 1.9.0-beta.0 snaps built.