### PR TITLE
Use dashboard 1.8.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 KUBE_ARCH=amd64
-KUBE_DASHBOARD_VERSION=v1.6.3
+KUBE_DASHBOARD_VERSION=v1.8.1
 KUBE_VERSION=$(shell curl -L https://dl.k8s.io/release/stable.txt)
 KUBE_ERSION=$(subst v,,${KUBE_VERSION})
 PWD=$(shell pwd)

--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -46,6 +46,7 @@ def render_template(file, context, required=True):
     # apply cdk-addons=true label
     data = [part for part in yaml.load_all(content) if part]
     for part in data:
+        part["metadata"].setdefault("labels", {})
         part["metadata"]["labels"]["cdk-addons"] = "true"
         # Adding kubernetes.io/cluster-service=true label for now. We should
         # probably remove this later and stop using it after the

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -104,7 +104,7 @@ def get_addon_templates():
 
     with kubernetes_dashboard_repo() as repo:
         log.info("Copying dashboard to " + dest)
-        add_addon(repo, "src/deploy/kubernetes-dashboard.yaml",
+        add_addon(repo, "src/deploy/recommended/kubernetes-dashboard.yaml",
                   dest, base='.')
 
 


### PR DESCRIPTION
Fix for the TLS-related 503 Service Error response we've been seeing.

In kubernetes-dashboard 1.7.0 they switched to using HTTPS instead of HTTP. The /ui/ endpoint on kube-apiserver 1.9.0 now tries to access the dashboard via HTTPS, so we need to catch up.