### PR TITLE
Making grafana root www url configurable

### DIFF
--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -18,6 +18,7 @@ def render_templates():
     os.mkdir(addon_dir)
     context = {
         "arch": get_snap_config("arch"),
+        "gfwww": get_snap_config("gf-www"),
         "pillar": {
             "dns_domain": get_snap_config("dns-domain"),
             "num_nodes": get_node_count()

--- a/cdk-addons/meta/hooks/configure
+++ b/cdk-addons/meta/hooks/configure
@@ -4,6 +4,6 @@ set -eu
 rm -rf "$SNAP_DATA/config"
 mkdir "$SNAP_DATA/config"
 
-for key in arch kubeconfig dns-domain enable-dashboard enable-kube-dns; do
+for key in arch kubeconfig dns-domain enable-dashboard enable-kube-dns gf-www; do
     snapctl get "$key" > "$SNAP_DATA/config/$key"
 done

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -67,7 +67,7 @@ def add_addon(repo, source, dest, required=True, base='cluster/addons'):
     """ Add an addon template from the given repo and source.
 
     Any occurrences of 'amd64' are replaced with '{{ arch }}' so the snap can
-    fill it in from config. """
+    fill it in from config. Same for grafana www root."""
     source = os.path.join(repo, base, source)
     if not os.path.exists(source) and not required:
         return
@@ -78,6 +78,8 @@ def add_addon(repo, source, dest, required=True, base='cluster/addons'):
         content = f.read()
     content = content.replace("amd64", "{{ arch }}")
     content = content.replace("clusterIP: {{ pillar['dns_server'] }}", "# clusterIP: {{ pillar['dns_server'] }}")
+    gfwww = "/api/v1/proxy/namespaces/kube-system/services/monitoring-grafana/"
+    content = content.replace(gfwww, "{{ gfwww }}")
     with open(dest, "w") as f:
         f.write(content)
 


### PR DESCRIPTION
This will allow users to expose grafana either from kubectl proxying, proxing through the master or expose the grafana metrics as normal service (LB or nodeport)