### PR TITLE
Bump dashboard to 1.8.3 to work with Kubernetes 1.9.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 KUBE_ARCH=amd64
-KUBE_DASHBOARD_VERSION=v1.8.1
+KUBE_DASHBOARD_VERSION=v1.8.3
 KUBE_VERSION=$(shell curl -L https://dl.k8s.io/release/stable.txt)
 KUBE_ERSION=$(subst v,,${KUBE_VERSION})
 PWD=$(shell pwd)


### PR DESCRIPTION
Dashboard broke when we released 1.9.4. Pod gets stuck in a crash loop with this log output:
```
$ kubectl logs kubernetes-dashboard-7b7b5cd79b-95zqt -n kube-system
2018/03/12 22:15:43 Starting overwatch
2018/03/12 22:15:43 Using in-cluster config to connect to apiserver
2018/03/12 22:15:43 Using service account token for csrf signing
2018/03/12 22:15:43 No request provided. Skipping authorization
2018/03/12 22:15:43 Successful initial request to the apiserver, version: v1.9.4
2018/03/12 22:15:43 Generating JWE encryption key
2018/03/12 22:15:43 New synchronizer has been registered: kubernetes-dashboard-key-holder-kube-system. Starting
2018/03/12 22:15:43 Starting secret synchronizer for kubernetes-dashboard-key-holder in namespace kube-system
2018/03/12 22:15:44 Initializing JWE encryption key from synchronized object
2018/03/12 22:15:44 Creating in-cluster Heapster client
2018/03/12 22:15:44 Auto-generating certificates
2018/03/12 22:15:44 [ECDSAManager] Failed to open dashboard.crt for writing: open /certs/dashboard.crt: read-only file system
```

This was fixed in kubernetes-dashboard 1.8.3, here: https://github.com/kubernetes/dashboard/pull/2795

Lightly tested, seems to work.