### PR TITLE
Fix heapster on 1.10 by passing in nanny_memory

### DIFF
--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -16,12 +16,16 @@ def main():
 def render_templates():
     shutil.rmtree(addon_dir, ignore_errors=True)
     os.mkdir(addon_dir)
+    node_count = get_node_count()
     context = {
         "arch": get_snap_config("arch"),
         "pillar": {
             "dns_domain": get_snap_config("dns-domain"),
-            "num_nodes": get_node_count()
-        }
+            "num_nodes": node_count
+        },
+        # nanny_memory for heapster
+        # formula from https://github.com/kubernetes/kubernetes/blob/v1.9.6/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml#L11
+        "nanny_memory": str(90 * 1024 + node_count * 200) + "Ki"
     }
     if get_snap_config("enable-kube-dns") == "true":
         render_template("kube-dns.yaml", context)


### PR DESCRIPTION
The error:

```
error: error validating "/root/snap/cdk-addons/x1/addons/heapster-controller.yaml": error validating data: [unknown object type "nil" in Deployment.spec.template.spec.containers[2].resources.limits.memory, unknown object type "nil" in Deployment.spec.template.spec.containers[2].resources.requests.memory, unknown object type "nil" in Deployment.spec.template.spec.containers[3].resources.limits.memory, unknown object type "nil" in Deployment.spec.template.spec.containers[3].resources.requests.memory]; if you choose to ignore these errors, turn validation off with --validate=false
```

This causes `cdk-addons.apply` to fail, preventing heapster and other addons from deploying, and leaving kubernetes-master stuck in a "Waiting to retry addon deployment." loop.

---
The cause:

The heapster_controller.yaml template expects a variable, `nanny_memory`, to use for memory resources limits in a few fields. ([link](https://github.com/kubernetes/kubernetes/blob/v1.10.0/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml#L86))

The `nanny_memory` var used to be set by default within the template, but that was removed in [this commit](https://github.com/kubernetes/kubernetes/pull/58564/commits/0d39648775c0a5ab2bb99754f9181c51adc29544). This template now requires `nanny_memory` to be passed in.

---
The fix:

Calculate and pass in `nanny_memory` ourselves from `cdk-addons.apply`.