### PR TITLE
Do not package the nvidia daemonset from upstream

### DIFF
--- a/get-addon-templates
+++ b/get-addon-templates
@@ -129,9 +129,6 @@ def get_addon_templates():
         # Heapster RBAC
         add_addon(repo, "cluster-monitoring/heapster-rbac.yaml", dest)
 
-        #nvidia device plugin
-        add_addon(repo, "device-plugins/nvidia-gpu/daemonset.yaml", dest)
-
         # metrics server
         add_addon(repo, "metrics-server/auth-delegator.yaml", dest)
         add_addon(repo, "metrics-server/auth-reader.yaml", dest)


### PR DESCRIPTION
This was left behind when we moved from the upstream daemonset to the one available from the nvidia plugin project. It is not used anymore. Was left behind here: https://github.com/juju-solutions/cdk-addons/commit/a248366daff806a543f24963d7096fdece90188f