### PR TITLE
support new registry option

### DIFF
--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -29,6 +29,11 @@ def render_templates():
         # formula from https://github.com/kubernetes/kubernetes/blob/v1.9.6/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml#L11
         "nanny_memory": str(90 * 1024 + node_count * 200) + "Ki"
     }
+
+    registry = get_snap_config("registry", required=False)
+    if registry:
+        context["registry"] = registry
+
     rendered = False
     if get_snap_config("enable-kube-dns") == "true":
         render_template("kube-dns.yaml", context)

--- a/cdk-addons/meta/hooks/configure
+++ b/cdk-addons/meta/hooks/configure
@@ -4,6 +4,7 @@ set -eu
 rm -rf "$SNAP_DATA/config"
 mkdir "$SNAP_DATA/config"
 
-for key in arch kubeconfig dns-domain enable-dashboard enable-kube-dns enable-metrics enable-gpu; do
+for key in arch kubeconfig dns-domain enable-dashboard enable-kube-dns \
+           enable-metrics enable-gpu registry; do
     snapctl get "$key" > "$SNAP_DATA/config/$key"
 done

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -2,6 +2,7 @@
 
 import argparse
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -102,9 +103,15 @@ def add_addon(repo, source, dest, required=True, base='cluster/addons'):
 		"k8s.gcr.io/addon-resizer:1.8.1",
 		"cdkbot/addon-resizer-{{ arch }}:1.8.1"
     )
-    content = content.replace("cdkbot", "{{ registry|default('cdkbot') }}")
-    content = content.replace("k8s.gcr.io", "{{ registry|default('k8s.gcr.io') }}")
-    content = content.replace("nvidia", "{{ registry|default('nvidia') }}")
+    # Make sure images come from the configured registry (or use the default)
+    content = re.sub(r"image:\s*cdkbot/",
+                     "image: {{ registry|default('cdkbot') }}/",
+                     content)
+    content = re.sub(r"image:\s*k8s.gcr.io/",
+                     "image: {{ registry|default('k8s.gcr.io') }}/",
+                     content)
+    content = re.sub(r"image:\s*nvidia/",
+                     "image: {{ registry|default('nvidia') }}/")
     with open(dest, "w") as f:
         f.write(content)
 

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -102,7 +102,9 @@ def add_addon(repo, source, dest, required=True, base='cluster/addons'):
 		"k8s.gcr.io/addon-resizer:1.8.1",
 		"cdkbot/addon-resizer-{{ arch }}:1.8.1"
     )
-
+    content = content.replace("cdkbot", "{{ registry|default('cdkbot') }}")
+    content = content.replace("k8s.gcr.io", "{{ registry|default('k8s.gcr.io') }}")
+    content = content.replace("nvidia", "{{ registry|default('nvidia') }}")
     with open(dest, "w") as f:
         f.write(content)
 

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -111,7 +111,8 @@ def add_addon(repo, source, dest, required=True, base='cluster/addons'):
                      "image: {{ registry|default('k8s.gcr.io') }}/",
                      content)
     content = re.sub(r"image:\s*nvidia/",
-                     "image: {{ registry|default('nvidia') }}/")
+                     "image: {{ registry|default('nvidia') }}/",
+                     content)
     with open(dest, "w") as f:
         f.write(content)
 


### PR DESCRIPTION
Let users specify the docker registry they wish to use when deploying
addons. This facilitates offline deployments.