### PR TITLE
Adding ceph templates

### DIFF
--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -58,11 +58,52 @@ def render_templates():
         render_template("metrics-server-service.yaml", context)
         render_template("resource-reader.yaml", context)
         rendered = True
+    if get_snap_config("enable-ceph", required=False) == "true":
+        ceph_context = context
+        default_storage = get_snap_config("default-storage", required=True)
+        ceph_context['admin_key'] = get_snap_config(
+            "ceph-admin-key", required=True)
+        ceph_context['kubernetes_key'] = get_snap_config(
+            "ceph-kubernetes-key", required=True)
+        ceph_context['mon_hosts'] = get_snap_config(
+            "ceph-mon-hosts", required=True)
+
+        render_template("rbd-secrets.yaml", ceph_context)
+        render_template("rbdplugin.yaml", ceph_context)
+        render_template("csi-provisioner.yaml", ceph_context)
+        render_template("csi-attacher.yaml", ceph_context)
+
+        ext4_context = ceph_context
+        if default_storage == 'ceph-ext4':
+            ext4_context['default'] = True
+        else:
+            ext4_context['default'] = False
+        ext4_context['pool_name'] = 'ext4-pool'
+        ext4_context['fs_type'] = 'ext4'
+        ext4_context['sc_name'] = 'ceph-ext4'
+        render_template("rbd-storage-class.yaml", ext4_context,
+                        render_filename="ceph-ext4-storage-class.yaml")
+
+        xfs_context = ceph_context
+        if (default_storage == 'ceph-xfs' or
+                default_storage == 'auto'):
+            xfs_context['default'] = True
+        else:
+            xfs_context['default'] = False
+        xfs_context['pool_name'] = 'xfs-pool'
+        xfs_context['fs_type'] = 'xfs'
+        xfs_context['sc_name'] = 'ceph-xfs'
+        render_template("rbd-storage-class.yaml", xfs_context,
+                        render_filename="ceph-xfs-storage-class.yaml")
+
     return rendered
 
-def render_template(file, context, required=True):
+def render_template(file, context, required=True, render_filename=None):
     source = os.path.join(template_dir, file)
-    dest = os.path.join(addon_dir, file)
+    if render_filename is None:
+        dest = os.path.join(addon_dir, file)
+    else:
+        dest = os.path.join(addon_dir, render_filename)
     if not os.path.exists(source) and not required:
         return
     with open(source) as f:
@@ -85,23 +126,19 @@ def apply_addons():
         dns_svc = os.path.join(addon_dir, "kube-dns.yaml")
         args = ["apply",
                 "-f", dns_svc,
-                "--namespace=kube-system",
                 "-l", "cdk-addons=true",
                 "--force"]
         kubectl(*args)
     args = ["apply",
             "-f", addon_dir,
             "--recursive",
-            "--namespace=kube-system",
             "-l", "cdk-addons=true",
             "--prune=true",
             "--force"]
     kubectl(*args)
 
 def remove_all_addons():
-    args = ["-n",
-            "kube-system",
-            "delete",
+    args = ["delete",
             "apiservices,"
             "clusterroles,"
             "clusterrolebindings,"

--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -59,7 +59,7 @@ def render_templates():
         render_template("resource-reader.yaml", context)
         rendered = True
     if get_snap_config("enable-ceph", required=False) == "true":
-        ceph_context = context
+        ceph_context = context.copy()
         default_storage = get_snap_config("default-storage", required=True)
         ceph_context['admin_key'] = get_snap_config(
             "ceph-admin-key", required=True)
@@ -73,7 +73,7 @@ def render_templates():
         render_template("csi-provisioner.yaml", ceph_context)
         render_template("csi-attacher.yaml", ceph_context)
 
-        ext4_context = ceph_context
+        ext4_context = ceph_context.copy()
         if default_storage == 'ceph-ext4':
             ext4_context['default'] = True
         else:
@@ -84,7 +84,7 @@ def render_templates():
         render_template("rbd-storage-class.yaml", ext4_context,
                         render_filename="ceph-ext4-storage-class.yaml")
 
-        xfs_context = ceph_context
+        xfs_context = ceph_context.copy()
         if (default_storage == 'ceph-xfs' or
                 default_storage == 'auto'):
             xfs_context['default'] = True

--- a/cdk-addons/meta/hooks/configure
+++ b/cdk-addons/meta/hooks/configure
@@ -5,6 +5,8 @@ rm -rf "$SNAP_DATA/config"
 mkdir "$SNAP_DATA/config"
 
 for key in arch kubeconfig dns-domain enable-dashboard enable-kube-dns \
-           enable-metrics enable-gpu registry; do
+		enable-metrics enable-gpu registry \
+		ceph-admin-key ceph-kubernetes-key ceph-mon-hosts ceph-pool-name \
+		default-storage enable-ceph; do
     snapctl get "$key" > "$SNAP_DATA/config/$key"
 done

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -80,6 +80,20 @@ def nvidia_plugin_repo():
         shutil.rmtree(path)
 
 
+@contextmanager
+def ceph_csi_repo():
+    """ Yield a ceph CSI repo from which to copy template yaml. """
+    repo = "http://github.com/ceph/ceph-csi.git"
+    log.info("Cloning %s" % (repo))
+    path = tempfile.mkdtemp(prefix="ceph")
+    try:
+        cmd = ["git", "clone", repo, path, "--depth", "1"]
+        run_with_logging(cmd)
+        yield path
+    finally:
+        shutil.rmtree(path)
+
+
 def add_addon(repo, source, dest, required=True, base='cluster/addons'):
     """ Add an addon template from the given repo and source.
 
@@ -128,6 +142,39 @@ def patch_plugin_manifest(repo, file):
         yaml.dump(manifest, yaml_file, default_flow_style=False)
 
 
+def patch_ceph_secret(repo, file):
+    source = os.path.join(repo, file)
+    with open(source) as stream:
+        manifest = yaml.load(stream)
+    manifest['data']['admin'] = "{{ admin_key }}"
+    manifest['data']['kubernetes'] = "{{ kubernetes_key }}"
+    with open(source, 'w') as yaml_file:
+        yaml.dump(manifest, yaml_file, default_flow_style=False)
+
+
+def patch_ceph_storage_class(repo, file):
+    source = os.path.join(repo, file)
+    with open(source) as stream:
+        manifest = yaml.load(stream)
+    manifest['parameters']['monitors'] = "{{ monitors }}"
+    manifest['parameters']['pool'] = "{{ pool_name }}"
+    manifest['parameters']['fsType'] = "{{ fs_type }}"
+    manifest['metadata']['name'] = "{{ sc_name }}"
+    with open(source, 'w') as yaml_file:
+        yaml.dump(manifest, yaml_file, default_flow_style=False)
+
+    # :-/ Would be nice to be able to add this template a different way
+    with open(source, "r") as f:
+        content = f.read()
+    content = content.replace("metadata:", """metadata:
+{% if default == true %}
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+{% endif %}""")
+    with open(source, "w") as f:
+        f.write(content)
+
+
 def get_addon_templates():
     """ Get addon templates. This will clone the kubernetes repo from upstream
     and copy addons to ./templates """
@@ -165,6 +212,18 @@ def get_addon_templates():
         log.info("Copying nvidia plugin to " + dest)
         patch_plugin_manifest(repo, "nvidia-device-plugin.yml")
         add_addon(repo, "nvidia-device-plugin.yml", dest, base='.')
+
+    with ceph_csi_repo() as repo:
+        log.info("Copying ceph CSI templates to " + dest)
+        add_addon(repo, "deploy/rbd/kubernetes/csi-provisioner.yaml", dest, base='.')
+        add_addon(repo, "deploy/rbd/kubernetes/csi-attacher.yaml", dest, base='.')
+        add_addon(repo, "deploy/rbd/kubernetes/rbdplugin.yaml", dest, base='.')
+
+        patch_ceph_secret(repo, "deploy/rbd/kubernetes/rbd-secrets.yaml")
+        add_addon(repo, "deploy/rbd/kubernetes/rbd-secrets.yaml", dest, base='.')
+
+        patch_ceph_storage_class(repo, "deploy/rbd/kubernetes/rbd-storage-class.yaml")
+        add_addon(repo, "deploy/rbd/kubernetes/rbd-storage-class.yaml", dest, base='.')
 
 
 def parse_args():

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -156,7 +156,7 @@ def patch_ceph_storage_class(repo, file):
     source = os.path.join(repo, file)
     with open(source) as stream:
         manifest = yaml.load(stream)
-    manifest['parameters']['monitors'] = "{{ monitors }}"
+    manifest['parameters']['mon_hosts'] = "{{ monitors }}"
     manifest['parameters']['pool'] = "{{ pool_name }}"
     manifest['parameters']['fsType'] = "{{ fs_type }}"
     manifest['metadata']['name'] = "{{ sc_name }}"

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -156,7 +156,7 @@ def patch_ceph_storage_class(repo, file):
     source = os.path.join(repo, file)
     with open(source) as stream:
         manifest = yaml.load(stream)
-    manifest['parameters']['mon_hosts'] = "{{ monitors }}"
+    manifest['parameters']['monitors'] = "{{ mon_hosts }}"
     manifest['parameters']['pool'] = "{{ pool_name }}"
     manifest['parameters']['fsType'] = "{{ fs_type }}"
     manifest['metadata']['name'] = "{{ sc_name }}"


### PR DESCRIPTION
These templates are actually a data store and not rendered by apply. This allows us to have and render templates in the charms, but still have different templates based on k8s revision for things like alpha -> beta transitions. The data that would have to be passed down to cdk-addons would be somewhat extreme with possible encoding issues. As a result, this was handled as the charm rendering the template and cdk-addons just a data carrier.

This can go in before the charm code as it doesn't depend on it, but the charm code obviously does depend on this.