### PR TITLE
Swapping over to use the cdk-addons label

### DIFF
--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -74,10 +74,6 @@ def render_template(file, context, required=True):
     for part in data:
         part["metadata"].setdefault("labels", {})
         part["metadata"]["labels"]["cdk-addons"] = "true"
-        # Adding kubernetes.io/cluster-service=true label for now. We should
-        # probably remove this later and stop using it after the
-        # cdk-addons=true label has been live for a couple releases.
-        part["metadata"]["labels"]["kubernetes.io/cluster-service"] = "true"
     content = yaml.dump_all(data)
 
     with open(dest, "w") as f:
@@ -90,14 +86,14 @@ def apply_addons():
         args = ["apply",
                 "-f", dns_svc,
                 "--namespace=kube-system",
-                "-l", "kubernetes.io/cluster-service=true",
+                "-l", "cdk-addons=true",
                 "--force"]
         kubectl(*args)
     args = ["apply",
             "-f", addon_dir,
             "--recursive",
             "--namespace=kube-system",
-            "-l", "kubernetes.io/cluster-service=true",
+            "-l", "cdk-addons=true",
             "--prune=true",
             "--force"]
     kubectl(*args)
@@ -116,8 +112,7 @@ def remove_all_addons():
             "secrets,"
             "services,"
             "serviceaccounts",
-            "-l",
-            "kubernetes.io/cluster-service=true",
+            "-l", "cdk-addons=true",
             "--force"]
     kubectl(*args)
 


### PR DESCRIPTION
Originally set cdk-addons label in version 1.8. It should be safe to switch to use this now and doing so prevents us from deleting other system pods inadvertently.