### PR TITLE
Fix ceph-csi not getting deleted in 1.10

### DIFF
--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -162,7 +162,11 @@ def prune_addons():
                 data = yaml.load_all(f)
                 for part in data:
                     kind = part['kind']
-                    namespace = part['metadata'].get('namespace')
+                    # If no namespace is specified, it's either an unnamespaced
+                    # resource, or a namespaced resource that will end up in
+                    # 'default'. We can delete both in the same way so we may
+                    # as well put them in the same bucket.
+                    namespace = part['metadata'].get('namespace', 'default')
                     name = part['metadata']['name']
                     current_addons.add((kind, namespace, name))
 
@@ -192,7 +196,9 @@ def prune_addons():
     for item in data['items']:
         kind = item['kind']
         metadata = item['metadata']
-        namespace = metadata.get('namespace')
+        # Depending on k8s version, unnamespaced resources can be returned as
+        # None or "".
+        namespace = metadata.get('namespace') or 'default'
         name = metadata['name']
 
         # skip if it's a current addon
@@ -201,9 +207,7 @@ def prune_addons():
 
         # it has our label but isn't a current addon, delete it!
         print('Deleting %s %s/%s' % (kind, namespace, name))
-        args = ['delete', kind, name]
-        if namespace:
-            args += ['-n', namespace]
+        args = ['delete', kind, name, '-n', namespace]
         try:
             kubectl(*args)
         except subprocess.CalledProcessError:

--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -199,7 +199,7 @@ def prune_addons():
 
         # it has our label but isn't a current addon, delete it!
         print('Deleting %s %s/%s' % (kind, namespace, name))
-        args = ['delete', '--wait=false', kind, name]
+        args = ['delete', kind, name]
         if namespace:
             args += ['-n', namespace]
         try:

--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -176,13 +176,15 @@ def prune_addons():
             'clusterroles',
             'clusterrolebindings',
             'configmaps',
+            'daemonsets',
             'deployments',
             'pods',
             'roles',
             'rolebindings',
             'secrets',
             'services',
-            'serviceaccounts'
+            'serviceaccounts',
+            'statefulsets'
         ])
     )
     data = json.loads(output)


### PR DESCRIPTION
Fixes https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/680

The previous fix missed a couple things:
1. ceph-csi DaemonSets and StatefulSets were not cleaned up
2. The `kubectl delete --wait` flag was not introduced until kubectl 1.11