### PR TITLE
Set token auth parameter for dashboard.

### DIFF
--- a/get-addon-templates
+++ b/get-addon-templates
@@ -234,7 +234,7 @@ def patch_dashboard(repo, file):
         content = f.read()
     content = content.replace("- --auto-generate-certificates",
                               """- --auto-generate-certificates
-          - --authentication-mode=basic""")
+          - --authentication-mode=token""")
     with open(source, "w") as f:
         f.write(content)
 


### PR DESCRIPTION
Forcing authentication mode to basic seems to be breaking token authentication.

(we are using token authentication for the kubernetes dashboard in our deployment)