### PR TITLE
Adding dashboard auth parameter to cdk-addons

### DIFF
--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -56,7 +56,10 @@ def render_templates():
     if get_snap_config("enable-dashboard") == "true":
         dash_context = context.copy()
         dash_context['dashboard_auth'] = get_snap_config(
-            "dashboard-auth", required=True)
+            "dashboard-auth", required=False)
+        if not dash_context['dashboard_auth']:
+            # default to basic auth as it used to be hard-coded
+            dash_context['dashboard_auth'] = 'basic'
         render_template("kubernetes-dashboard.yaml", dash_context)
         render_template("influxdb-grafana-controller.yaml", dash_context)
         render_template("influxdb-service.yaml", dash_context)

--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -54,13 +54,16 @@ def render_templates():
         render_template("kube-dns.yaml", context)
         rendered = True
     if get_snap_config("enable-dashboard") == "true":
-        render_template("kubernetes-dashboard.yaml", context)
-        render_template("influxdb-grafana-controller.yaml", context)
-        render_template("influxdb-service.yaml", context)
-        render_template("grafana-service.yaml", context)
-        render_template("heapster-rbac.yaml", context)
-        render_template("heapster-controller.yaml", context)
-        render_template("heapster-service.yaml", context)
+        dash_context = context.copy()
+        dash_context['dashboard_auth'] = get_snap_config(
+            "dashboard-auth", required=True)
+        render_template("kubernetes-dashboard.yaml", dash_context)
+        render_template("influxdb-grafana-controller.yaml", dash_context)
+        render_template("influxdb-service.yaml", dash_context)
+        render_template("grafana-service.yaml", dash_context)
+        render_template("heapster-rbac.yaml", dash_context)
+        render_template("heapster-controller.yaml", dash_context)
+        render_template("heapster-service.yaml", dash_context)
         rendered = True
     if get_snap_config("enable-gpu", required=False) == "true":
         render_template("nvidia-device-plugin.yml", context)

--- a/cdk-addons/meta/hooks/configure
+++ b/cdk-addons/meta/hooks/configure
@@ -8,6 +8,7 @@ for key in arch kubeconfig dns-domain enable-dashboard enable-kube-dns \
 		enable-metrics enable-gpu registry \
 		ceph-admin-key ceph-kubernetes-key ceph-mon-hosts ceph-pool-name \
 		default-storage enable-ceph enable-keystone keystone-server-url \
-                keystone-cert-file keystone-key-file keystone-ssl-ca; do
-    snapctl get "$key" > "$SNAP_DATA/config/$key"
+		keystone-cert-file keystone-key-file keystone-ssl-ca \
+		dashboard-auth; do
+	snapctl get "$key" > "$SNAP_DATA/config/$key"
 done

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -248,7 +248,7 @@ def patch_dashboard(repo, file):
         content = f.read()
     content = content.replace("- --auto-generate-certificates",
                               """- --auto-generate-certificates
-          - --authentication-mode=basic""")
+          - --authentication-mode={{ dashboard_auth }}""")
     with open(source, "w") as f:
         f.write(content)
 


### PR DESCRIPTION
https://github.com/juju-solutions/kubernetes/pull/222 is needed first. Since dashboard-auth is a required parameter, we have to ensure that no build of cdk-addons is tied a kubernetes-master charm that isn't setting the parameter.