### PR TITLE
Add CoreDNS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 KUBE_ARCH=amd64
-# need to jump to master to get 1.10.1 for CVE-2018-18264
+COREDNS_COMMIT=3ec05335204d92842edb288f10c715bc84333960
 KUBE_DASHBOARD_VERSION=v1.10.1
 KUBE_VERSION=$(shell curl -L https://dl.k8s.io/release/stable.txt)
 KUBE_ERSION=$(subst v,,${KUBE_VERSION})
@@ -8,7 +8,7 @@ BUILD=build
 
 default: clean
 	cp -r cdk-addons ${BUILD}
-	KUBE_VERSION=${KUBE_VERSION} KUBE_DASHBOARD_VERSION=${KUBE_DASHBOARD_VERSION} ./get-addon-templates
+	KUBE_VERSION=${KUBE_VERSION} KUBE_DASHBOARD_VERSION=${KUBE_DASHBOARD_VERSION} COREDNS_COMMIT=${COREDNS_COMMIT} ./get-addon-templates
 	mv templates ${BUILD}
 	wget -O ${BUILD}/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/${KUBE_ARCH}/kubectl
 	chmod +x ${BUILD}/kubectl

--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -12,6 +12,10 @@ from jinja2 import Template
 
 template_dir = os.path.join(os.environ["SNAP"], "templates")
 addon_dir = os.path.join(os.environ["SNAP_USER_DATA"], "addons")
+dns_providers = {
+    'core-dns': 'core-dns.yaml',
+    'kube-dns': 'kube-dns.yaml'
+}
 
 def main():
     if render_templates():
@@ -50,8 +54,9 @@ def render_templates():
         context["registry"] = registry
 
     rendered = False
-    if get_snap_config("enable-kube-dns") == "true":
-        render_template("kube-dns.yaml", context)
+    dns_provider = get_snap_config("dns-provider")
+    if dns_provider in dns_providers:
+        render_template(dns_providers[dns_provider], context)
         rendered = True
     if get_snap_config("enable-dashboard") == "true":
         render_template("kubernetes-dashboard.yaml", context)
@@ -161,8 +166,9 @@ def render_template(file, context, required=True, render_filename=None):
 
 def apply_addons():
     # Apply dns service first and then recursively the rest.
-    if get_snap_config("enable-kube-dns") == "true":
-        dns_svc = os.path.join(addon_dir, "kube-dns.yaml")
+    dns_provider = get_snap_config("dns-provider")
+    if dns_provider in dns_providers:
+        dns_svc = os.path.join(addon_dir, dns_providers[dns_provider])
         args = ["apply",
                 "-f", dns_svc,
                 "-l", "cdk-addons=true",

--- a/cdk-addons/meta/hooks/configure
+++ b/cdk-addons/meta/hooks/configure
@@ -4,7 +4,7 @@ set -eu
 rm -rf "$SNAP_DATA/config"
 mkdir "$SNAP_DATA/config"
 
-for key in arch kubeconfig dns-domain enable-dashboard enable-kube-dns \
+for key in arch kubeconfig dns-domain enable-dashboard dns-provider \
 		enable-metrics enable-gpu registry \
 		ceph-admin-key ceph-kubernetes-key ceph-mon-hosts ceph-pool-name \
 		default-storage enable-ceph enable-keystone keystone-server-url \

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -23,10 +23,10 @@ logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 log = logging.getLogger(__name__)
 
 
-def run_with_logging(command):
+def run_with_logging(command, cwd=None):
     """ Run a command with controlled logging """
     log.debug("Running: %s" % command)
-    process = subprocess.Popen(command, stderr=subprocess.PIPE)
+    process = subprocess.Popen(command, cwd=cwd, stderr=subprocess.PIPE)
     stderr = process.communicate()[1].rstrip()
     process.wait()
     if process.returncode != 0:
@@ -36,14 +36,23 @@ def run_with_logging(command):
 
 
 @contextmanager
-def cloned_repo(url, branch=None):
-    log.info("Cloning %s with branch %s" % (url, branch))
+def cloned_repo(url, branch=None, commit=None):
+    log.info("Cloning %s%s%s" % (
+        url,
+        " branch " + branch if branch else "",
+        " commit " + commit if commit else ""
+    ))
     path = tempfile.mkdtemp(prefix="cdk-addons-cloned-repo")
     try:
-        cmd = ["git", "clone", url, path, "--depth", "1", "--single-branch"]
+        cmd = ["git", "clone", url, path]
+        if not commit:
+            cmd += ['--single-branch', '--depth', '1']
         if branch:
             cmd += ["-b", branch]
         run_with_logging(cmd)
+        if commit:
+            cmd = ["git", "checkout", commit]
+            run_with_logging(cmd, cwd=path)
         yield path
     finally:
         shutil.rmtree(path)
@@ -73,6 +82,11 @@ ceph_csi_repo = repo_cloner(
 
 cloud_provider_openstack_repo = repo_cloner(
     url="https://github.com/kubernetes/cloud-provider-openstack.git"
+)
+
+coredns_repo = repo_cloner(
+    url="https://github.com/coredns/deployment.git",
+    commit=os.environ["COREDNS_COMMIT"]
 )
 
 
@@ -221,6 +235,22 @@ def patch_dashboard(repo, file):
         f.write(content)
 
 
+def patch_coredns(repo, file):
+    source = os.path.join(repo, file)
+    with open(source, "r") as f:
+        content = f.read()
+    content = content.replace("CLUSTER_DOMAIN", "{{ pillar['dns_domain'] }}")
+    content = content.replace("REVERSE_CIDRS", "in-addr.arpa ip6.arpa")
+    content = content.replace("FEDERATIONS", "")
+    content = content.replace("UPSTREAMNAMESERVER", "/etc/resolv.conf")
+    content = content.replace("STUBDOMAINS", "")
+    # Let Kubernetes handle the service IP. When upgrading from kube-dns it
+    # will stay the same on its own.
+    content = content.replace("clusterIP: CLUSTER_DNS_IP", "#clusterIP: CLUSTER_DNS_IP")
+    with open(source, "w") as f:
+        f.write(content)
+
+
 def get_addon_templates():
     """ Get addon templates. This will clone the kubernetes repo from upstream
     and copy addons to ./templates """
@@ -288,6 +318,11 @@ def get_addon_templates():
         add_addon(repo, "examples/webhook/keystone-deployment.yaml", dest, base='.')
         add_addon(repo, "examples/webhook/keystone-service.yaml", dest, base='.')
         add_addon(repo, "examples/webhook/keystone-rbac.yaml", dest, base='.')
+
+    with coredns_repo() as repo:
+        log.info("Copying coredns template to " + dest)
+        patch_coredns(repo, "kubernetes/coredns.yaml.sed")
+        add_addon(repo, "kubernetes/coredns.yaml.sed", dest + "/core-dns.yaml", base='.')
 
 
 def parse_args():

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -10,6 +10,7 @@ import tempfile
 import logging
 import yaml
 from contextlib import contextmanager
+from functools import partial
 
 
 description = """
@@ -35,77 +36,44 @@ def run_with_logging(command):
 
 
 @contextmanager
-def kubernetes_repo():
-    """ Yield a kubernetes repo to copy addons from. """
-    repo = "https://github.com/kubernetes/kubernetes.git"
-    branch = os.environ["KUBE_VERSION"]
-    log.info("Cloning %s with branch %s" % (repo, branch))
-    path = tempfile.mkdtemp(prefix="kubernetes")
+def cloned_repo(url, branch=None):
+    log.info("Cloning %s with branch %s" % (url, branch))
+    path = tempfile.mkdtemp(prefix="cdk-addons-cloned-repo")
     try:
-        cmd = ["git", "clone", repo, path, "-b", branch, "--depth", "1",
-               "--single-branch"]
+        cmd = ["git", "clone", url, path, "--depth", "1", "--single-branch"]
+        if branch:
+            cmd += ["-b", branch]
         run_with_logging(cmd)
         yield path
     finally:
         shutil.rmtree(path)
 
 
-@contextmanager
-def kubernetes_dashboard_repo():
-    """ Yield a kubernetes dashboard repo to copy yamls from. """
-    repo = "https://github.com/kubernetes/dashboard.git"
-    tag = os.environ["KUBE_DASHBOARD_VERSION"]
-    log.info("Cloning %s and moving to %s" % (repo, tag))
-    path = tempfile.mkdtemp(prefix="dashboard")
-    try:
-        cmd = ["git", "clone", repo, path, "-b", tag, "--depth", "1",
-               "--single-branch"]
-        run_with_logging(cmd)
-        yield path
-    finally:
-        shutil.rmtree(path)
+def repo_cloner(*args, **kwargs):
+    return partial(cloned_repo, *args, **kwargs)
 
 
-@contextmanager
-def nvidia_plugin_repo():
-    """ Yield a nvidia plugin repo to copy yaml from. """
-    repo = "https://github.com/NVIDIA/k8s-device-plugin.git"
-    log.info("Cloning %s" % (repo))
-    path = tempfile.mkdtemp(prefix="nvidia")
-    try:
-        cmd = ["git", "clone", repo, path, "--depth", "1"]
-        run_with_logging(cmd)
-        yield path
-    finally:
-        shutil.rmtree(path)
+kubernetes_repo = repo_cloner(
+    url="https://github.com/kubernetes/kubernetes.git",
+    branch=os.environ["KUBE_VERSION"]
+)
 
+kubernetes_dashboard_repo = repo_cloner(
+    url="https://github.com/kubernetes/dashboard.git",
+    branch=os.environ["KUBE_DASHBOARD_VERSION"]
+)
 
-@contextmanager
-def ceph_csi_repo():
-    """ Yield a ceph CSI repo from which to copy template yaml. """
-    repo = "http://github.com/ceph/ceph-csi.git"
-    log.info("Cloning %s" % (repo))
-    path = tempfile.mkdtemp(prefix="ceph")
-    try:
-        cmd = ["git", "clone", repo, path, "--depth", "1"]
-        run_with_logging(cmd)
-        yield path
-    finally:
-        shutil.rmtree(path)
+nvidia_plugin_repo = repo_cloner(
+    url="https://github.com/NVIDIA/k8s-device-plugin.git"
+)
 
+ceph_csi_repo = repo_cloner(
+    url="http://github.com/ceph/ceph-csi.git"
+)
 
-@contextmanager
-def cloud_provider_openstack_repo():
-    """ Yield a cloud provider openstack repo from which to copy template yaml. """
-    repo = "https://github.com/kubernetes/cloud-provider-openstack.git"
-    log.info("Cloning %s" % (repo))
-    path = tempfile.mkdtemp(prefix="openstack")
-    try:
-        cmd = ["git", "clone", repo, path, "--depth", "1"]
-        run_with_logging(cmd)
-        yield path
-    finally:
-        shutil.rmtree(path)
+cloud_provider_openstack_repo = repo_cloner(
+    url="https://github.com/kubernetes/cloud-provider-openstack.git"
+)
 
 
 def add_addon(repo, source, dest, required=True, base='cluster/addons'):


### PR DESCRIPTION
This adds CoreDNS to cdk-addons.

* Removed enable-kube-dns config
* Added dns-provider config (required) which can be "core-dns", "kube-dns", or "none"
  * Technically "none" isn't special, any value besides "core-dns" or "kube-dns" counts as none

This will not be backported to cdk-addons 1.13 or 1.12, and the charm will be updated to use the new dns-provider config for 1.14+, so it should be safe to change the params like this.