### PR TITLE
Patch to CoreDNS 1.4.0

### DIFF
--- a/get-addon-templates
+++ b/get-addon-templates
@@ -247,6 +247,9 @@ def patch_coredns(repo, file):
     # Let Kubernetes handle the service IP. When upgrading from kube-dns it
     # will stay the same on its own.
     content = content.replace("clusterIP: CLUSTER_DNS_IP", "#clusterIP: CLUSTER_DNS_IP")
+    # Make sure we're on CoreDNS 1.4.0+ to avoid issue
+    # https://github.com/coredns/coredns/issues/2629
+    content = content.replace("image: coredns/coredns:1.3.1", "image: coredns/coredns:1.4.0")
     with open(source, "w") as f:
         f.write(content)
 


### PR DESCRIPTION
Tested with this change. I verified the following:
* CoreDNS 1.4.0 was in use.
* DNS resolution worked within the cluster (from pods).
* CoreDNS pods did not log any obvious errors.
* Restarting kube-apiserver did not cause CoreDNS to crash.