### PR TITLE
Fixing custom CA in Keystone

### DIFF
--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -138,8 +138,8 @@ def render_templates():
                 base64.b64encode(image_file.read()).decode('utf-8')
         keystone_context['keystone_server_url'] = get_snap_config(
             "keystone-server-url", required=True)
-        keystone_context['keystone_ssl_ca'] = get_snap_config(
-            "keystone-ssl-ca", required=False)
+        keystone_context['keystone_ca_file'] = get_snap_config(
+            "keystone-server-ca", required=False).replace('\n', '')
 
         render_template("keystone-auth-certs-secret.yaml", keystone_context)
         render_template("keystone-deployment.yaml", keystone_context)

--- a/cdk-addons/apply
+++ b/cdk-addons/apply
@@ -138,7 +138,7 @@ def render_templates():
                 base64.b64encode(image_file.read()).decode('utf-8')
         keystone_context['keystone_server_url'] = get_snap_config(
             "keystone-server-url", required=True)
-        keystone_context['keystone_ca_file'] = get_snap_config(
+        keystone_context['keystone_server_ca'] = get_snap_config(
             "keystone-server-ca", required=False).replace('\n', '')
 
         render_template("keystone-auth-certs-secret.yaml", keystone_context)

--- a/cdk-addons/meta/hooks/configure
+++ b/cdk-addons/meta/hooks/configure
@@ -8,7 +8,7 @@ for key in arch kubeconfig dns-domain enable-dashboard dns-provider \
 		enable-metrics enable-gpu registry \
 		ceph-admin-key ceph-kubernetes-key ceph-mon-hosts ceph-pool-name \
 		default-storage enable-ceph enable-keystone keystone-server-url \
-		keystone-cert-file keystone-key-file keystone-ssl-ca \
+		keystone-cert-file keystone-key-file keystone-server-ca \
 		dashboard-auth; do
 	snapctl get "$key" > "$SNAP_DATA/config/$key"
 done

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -209,9 +209,12 @@ def patch_metrics_reader(repo, file):
 
 
 def patch_keystone_secret(repo, file):
+    ''' Add the ca-file to the secret that has the client cert and
+    client key. This will get injected into the pod at
+    /etc/kubernetes/pki in the container. '''
     source = os.path.join(repo, file)
     with open(source, "a") as f:
-        f.write('  ca-file: {{ keystone_ca_file }}\n')
+        f.write('{% if keystone_server_ca %}\n  ca-file: {{ keystone_server_ca }}\n{% endif %}\n')
 
 
 def patch_keystone_deployment(repo, file):
@@ -222,7 +225,7 @@ def patch_keystone_deployment(repo, file):
     content = content.replace('image: k8scloudprovider/k8s-keystone-auth',
                               'image: {{ registry|default("k8scloudprovider") }}/k8s-keystone-auth') # noqa
     content = content.replace("            - --keystone-url",
-                              """{% if keystone_ca_file %}
+                              """{% if keystone_server_ca %}
             - --keystone-ca-file
             - /etc/kubernetes/pki/ca-file
 {% endif %}

--- a/get-addon-templates
+++ b/get-addon-templates
@@ -208,6 +208,12 @@ def patch_metrics_reader(repo, file):
         yaml.dump_all(manifest, yaml_file, default_flow_style=False)
 
 
+def patch_keystone_secret(repo, file):
+    source = os.path.join(repo, file)
+    with open(source, "a") as f:
+        f.write('  ca-file: {{ keystone_ca_file }}\n')
+
+
 def patch_keystone_deployment(repo, file):
     source = os.path.join(repo, file)
     # :-/ Would be nice to be able to add this template a different way
@@ -216,9 +222,9 @@ def patch_keystone_deployment(repo, file):
     content = content.replace('image: k8scloudprovider/k8s-keystone-auth',
                               'image: {{ registry|default("k8scloudprovider") }}/k8s-keystone-auth') # noqa
     content = content.replace("            - --keystone-url",
-                              """{% if keystone_ssl_ca %}
-            - --keystone-ssl-ca
-            - {{ keystone_ssl_ca }}
+                              """{% if keystone_ca_file %}
+            - --keystone-ca-file
+            - /etc/kubernetes/pki/ca-file
 {% endif %}
             - --keystone-url""")
     with open(source, "w") as f:
@@ -316,9 +322,10 @@ def get_addon_templates():
 
     with cloud_provider_openstack_repo() as repo:
         log.info("Copying openstack tempates to " + dest)
-        add_addon(repo, "examples/webhook/keystone-auth-certs-secret.yaml", dest, base='.')
-
+        patch_keystone_secret(repo, "examples/webhook/keystone-auth-certs-secret.yaml")
         patch_keystone_deployment(repo, "examples/webhook/keystone-deployment.yaml")
+
+        add_addon(repo, "examples/webhook/keystone-auth-certs-secret.yaml", dest, base='.')
         add_addon(repo, "examples/webhook/keystone-deployment.yaml", dest, base='.')
         add_addon(repo, "examples/webhook/keystone-service.yaml", dest, base='.')
         add_addon(repo, "examples/webhook/keystone-rbac.yaml", dest, base='.')


### PR DESCRIPTION
Custom CA was pretty broken for Keystone. This PR fixes it. I chose to keep the naming from the kubernetes-master charm, keystone-server-ca, to prevent having to push changes to multiple repos.

Also, the CA was being just passed directly on the command line, but the parameter is designed to take a filename, not the actual cert. Added the CA to the secret and injected it into the pod beside the others. This seemed clean.